### PR TITLE
Past events enhancement

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,16 @@ N/A
 -->
 
 ---
+## [1.1.0] - 2023-09-06
+ 
+### Added
+- Added transparent shadows to EventAlbum text
+- Clicking on gallery image now opens it in full-screen
+
+### Updated
+- Cover image for EventAlbum is now takem from the Photo album instead of the poster
+- For events with only cover images, stock image is chosen as the cover
+
 
 ## [1.1.1] - 2023-08-24
 ### Updated

--- a/components/EventAlbum/EventAlbum.tsx
+++ b/components/EventAlbum/EventAlbum.tsx
@@ -17,19 +17,22 @@ export default function EventAlbum({ pastEvents }: any) {
         let date = parseDate(meetupEvent.dateTime.split("T")[0]);                   
         
         return (
-          <Link key={meetupEvent.id} href='/pastEvents/[eventId]/photoAlbum' as={`/pastEvents/${meetupEvent.id}/photoAlbum?photoCount=${meetupEvent.photoAlbum?.photoCount}`} className="flex w-1/2 px-4 pb-8 flex-wrap">          
-            <div className="relative text-center">
-              
+          <Link key={meetupEvent.id} 
+          href='/pastEvents/[eventId]/photoAlbum' 
+          as={`/pastEvents/${meetupEvent.id}/photoAlbum?photoCount=${meetupEvent.photoAlbum?.photoCount}`} 
+          className="flex w-1/2 px-4 pb-8 flex-wrap">
+            <div className="relative text-center">              
               <img
                 src={`${meetupEvent.image?.baseUrl}${meetupEvent.image?.id}/676x380.jpg`}
                 className="block rounded-xl object-center object-cover w-full h-full aspect-square"
                 alt=""
               />
-
-              <h1 className={`font-bold absolute text-2xl text-white w-full top-1/2 -translate-y-1/2`}>
+              <h1 className={`font-bold absolute drop-shadow-md text-2xl text-white w-full top-1/2 -translate-y-1/2`}>
                 {`${date.month} ${date.day}, ${date.year}`}
-              </h1>              
-
+              </h1>                            
+              <h1 className={`font-bold absolute drop-shadow-md text-2xl text-white w-full top-1/2 translate-y-1/4`}>
+                  {`${meetupEvent.photoAlbum?.photoCount}`} photo(s)
+              </h1>
             </div>        
           </Link>
         );

--- a/components/EventAlbum/EventAlbum.tsx
+++ b/components/EventAlbum/EventAlbum.tsx
@@ -1,14 +1,61 @@
 import Link from 'next/link';
 import { parseDate } from '@/app/util/DateTime';
-
+import { MeetupEvent } from '@/app/types/domain/MeetupEvent';
+import { getEventPhotoAlbum } from '@/app/service/meetup/MeetupService';
 /*
 This photo album component is designed specifically for the Previous events section 
 Parameters- 
 images : An array of objects containing image links and overlay text 
  */
 
-export default function EventAlbum({ pastEvents }: any) {
-  
+
+
+export default function EventAlbum({ pastEvents }: any) {  
+
+  const  getCoverImage = async (meetupEvent: any) => {
+    
+    const stockImage = "https://secure-content.meetupstatic.com/images/classic-events/513011027/676x380.jpg";    
+    const eventPhotoAlbum = await getEventPhotoAlbum(meetupEvent.id, parseInt(meetupEvent.photoAlbum?.photoCount));
+    
+    // If there is only one image, return a stock image
+    if (meetupEvent.photoAlbum?.photoCount && meetupEvent.photoAlbum?.photoCount < 2) {
+
+      return(
+        <img
+          src={stockImage}
+          className="block rounded-xl object-center object-cover w-full h-full aspect-square"
+          alt=""
+        />
+      );
+
+    }    
+        
+    let coverImage = `${eventPhotoAlbum?.photoAlbum?.photoSample[0]?.baseUrl}${eventPhotoAlbum?.photoAlbum?.photoSample[0]?.id}` + '/676x380.jpg';
+        
+    if (meetupEvent.image?.baseUrl !== eventPhotoAlbum?.photoAlbum?.photoSample[0]?.baseUrl) {
+      
+      return(
+
+        <img
+          src={coverImage}
+          className="block rounded-xl object-center object-cover w-full h-full aspect-square"
+          alt=""
+        />
+      )
+    }
+
+    // The first image is the album cover. Choosing the second image
+    coverImage = `${eventPhotoAlbum?.photoAlbum?.photoSample[1]?.baseUrl}${eventPhotoAlbum?.photoAlbum?.photoSample[1]?.id}` + '/676x380.jpg';
+
+    return(
+      <img
+        src={coverImage}
+        className="block rounded-xl object-center object-cover w-full h-full aspect-square"
+        alt=""
+      />
+    )
+  }
+
   return (
     <div className="container flex flex-wrap">
       {
@@ -21,12 +68,10 @@ export default function EventAlbum({ pastEvents }: any) {
           href='/pastEvents/[eventId]/photoAlbum' 
           as={`/pastEvents/${meetupEvent.id}/photoAlbum?photoCount=${meetupEvent.photoAlbum?.photoCount}`} 
           className="flex w-1/2 px-4 pb-8 flex-wrap">
-            <div className="relative text-center">              
-              <img
-                src={`${meetupEvent.image?.baseUrl}${meetupEvent.image?.id}/676x380.jpg`}
-                className="block rounded-xl object-center object-cover w-full h-full aspect-square"
-                alt=""
-              />
+            <div className="relative text-center">
+              {              
+                getCoverImage(meetupEvent)
+              }
               <h1 className={`font-bold absolute drop-shadow-md text-2xl text-white w-full top-1/2 -translate-y-1/2`}>
                 {`${date.month} ${date.day}, ${date.year}`}
               </h1>                            

--- a/components/Gallery/Gallery.tsx
+++ b/components/Gallery/Gallery.tsx
@@ -1,16 +1,20 @@
+import Link from 'next/link';
+
 export default function Gallery({ photoAlbum }: any) {
   console.log(photoAlbum);
   return (
     <div className="container flex flex-wrap">
       {photoAlbum?.photoSample?.map((photo: any) => {
         return (
-          <div key={photo?.id} className="flex w-1/2 px-4 pb-8 flex-wrap">
+          <div key={photo?.id} className="flex w-1/2 px-4 pb-8 flex-wrap">            
             <div className="relative text-center">
+              <Link href={`${photo?.baseUrl}${photo?.id}/676x380.jpg`}>
               <img
                 src={`${photo?.baseUrl}${photo?.id}/676x380.jpg`}
                 className="block rounded-xl object-center object-cover w-full h-full aspect-square"
                 alt=""
               />
+              </Link>
             </div>
           </div>
         );


### PR DESCRIPTION
### Added
- Added transparent shadows to EventAlbum text
- Clicking on gallery image now opens it in full-screen

### Updated
- Cover image for EventAlbum is now takem from the Photo album instead of the poster
- For events with only cover images, stock image is chosen as the cover
